### PR TITLE
README documentation and global title fallback

### DIFF
--- a/Colab_YouTube_Transcription_Extractor.ipynb
+++ b/Colab_YouTube_Transcription_Extractor.ipynb
@@ -45,7 +45,7 @@
       "cell_type": "code",
       "source": [
         "# Update the link and string below then hit \"Run all\"\n",
-        "YOUTUBE_URL = \"https://www.youtube.com/watch?v=XXXXXXXXXXX\"",
+        "YOUTUBE_URL = \"https://www.youtube.com/watch?v=XXXXXXXXXXX\"\n",
         "VIDEO_TITLE_FALLBACK = \"INSERT VIDEO NAME\""
       ],
       "metadata": {

--- a/Colab_YouTube_Transcription_Extractor.ipynb
+++ b/Colab_YouTube_Transcription_Extractor.ipynb
@@ -17,8 +17,9 @@
     {
       "cell_type": "code",
       "source": [
-        "# Update the link below then hit \"Run all\"\n",
-        "YOUTUBE_URL = \"https://www.youtube.com/watch?v=XXXXXXXXXXX\""
+        "# Update the link and string below then hit \"Run all\"\n",
+        "YOUTUBE_URL = \"https://www.youtube.com/watch?v=XXXXXXXXXXX\"",
+        "VIDEO_TITLE_FALLBACK = \"INSERT VIDEO NAME\""
       ],
       "metadata": {
         "id": "tjP-tm3QZlkn"
@@ -48,7 +49,7 @@
         "    print(f\"Video Title: {video_title}\")\n",
         "except Exception as e:\n",
         "    print(e)\n",
-        "    video_title = \"INSERT VIDEO NAME\"\n",
+        "    video_title = VIDEO_TITLE_FALLBACK\n",
         "    if video_title == \"INSERT VIDEO NAME\":\n",
         "        raise ValueError(\"Please replace 'INSERT VIDEO NAME' manually and re-run the cell.\")"
       ],

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# colab-ytt-to-docs
-Google Colab notebook to extract YouTube Transcript to Google Docs
+# Colab YouTube Transcription Extractor
+
+Extract YouTube video transcripts and save them directly to Google Docs using Google Colab.
+
+## Features
+- Fetches YouTube video transcripts using the [youtube-transcript-api](https://github.com/jdepoix/youtube-transcript-api)
+- Saves the transcript to a new Google Doc in your Google Drive
+- Supports English and English (US) transcripts
+
+## How to Use in Google Colab
+
+1. **Open Google Colab**
+	- Go to [Google Colab](https://colab.research.google.com/).
+2. **Upload the Notebook**
+	- Download `Colab_YouTube_Transcription_Extractor.ipynb` from this repository.
+	- In Colab, click `File > Upload notebook` and select the file.
+3. **Set the YouTube URL and API Key**
+	 - In the first cell, replace the sample URL and title fallback with details for your target YouTube video link:
+		 ```python
+		 YOUTUBE_URL = "https://www.youtube.com/watch?v=XXXXXXXXXXX"
+         VIDEO_TITLE_FALLBACK = "INSERT VIDEO NAME"
+		 ```
+	 - Add your YouTube Data API key to Colab secrets:
+		 - In Colab, go to `Runtime > Manage secrets` and add a new secret named `YOUTUBE_DATA_API_KEY` with your API key value.
+         - Check the "Notebook access" toggle.
+	 - To register for a YouTube Data API key:
+		 1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+		 2. Create a new project (or select an existing one).
+		 3. Enable the YouTube Data API v3 for your project.
+		 4. Go to `APIs & Services > Credentials` and create an API key.
+		 5. Copy the API key and add it to Colab secrets as described above.
+4. **Run All Cells**
+	- Click `Runtime > Run all` to execute the notebook.
+	- Authenticate with your Google account when prompted.
+	- Provide your YouTube Data API key if required.
+	- **Note:** The notebook will ask for access to your Google Drive in order to create the transcript file. You must grant access to proceed.
+5. **Get the Transcript**
+	- The notebook will fetch the transcript and create a new Google Doc in your Drive.
+	- A shareable link to the document will be printed at the end.
+
+## Requirements
+- Google Colab
+- YouTube Data API key (for fetching video title)
+- Access to Google Drive
+
+## License
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Extract YouTube video transcripts and save them directly to Google Docs using Go
 ## Features
 - Fetches YouTube video transcripts using the [youtube-transcript-api](https://github.com/jdepoix/youtube-transcript-api)
 - Saves the transcript to a new Google Doc in your Google Drive
-- Supports English and English (US) transcripts
 
 ## How to Use in Google Colab
 


### PR DESCRIPTION
- Adds complete documentation for the notebook, including how to upload it to Google Colab, replace sample strings, register and add required API key, and authorize Google Drive.
- Moves embedded video title fallback string to top of notebook for ease of user editing